### PR TITLE
Allow square brackets in filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.cache
 build
 build_app
 out

--- a/OFS-lib/UI/OFS_Videoplayer.cpp
+++ b/OFS-lib/UI/OFS_Videoplayer.cpp
@@ -150,9 +150,8 @@ void VideoplayerWindow::MpvEvents(SDL_Event& ev) noexcept
 				break;
 			}
 			case MpvFilePath:
-				// I'm not sure if I own this memory :/
-				// But I can't free it so I will assume I don't
-				MpvData.filePath = *((const char**)(prop->data));
+                // Copy string to ensure we own the memory and control the lifetime
+				MpvData.filePath = std::string(*((const char**)(prop->data)));
 				notifyVideoLoaded();
 				break;
 			case MpvAbLoopA:
@@ -431,7 +430,7 @@ void VideoplayerWindow::setupVrMode() noexcept
 
 void VideoplayerWindow::notifyVideoLoaded() noexcept
 {
-	EventSystem::PushEvent(VideoEvents::MpvVideoLoaded, (void*)MpvData.filePath);
+	EventSystem::PushEvent(VideoEvents::MpvVideoLoaded, (void*)MpvData.filePath.c_str());
 }
 
 void VideoplayerWindow::drawVrVideo(ImDrawList* draw_list) noexcept

--- a/OFS-lib/UI/OFS_Videoplayer.h
+++ b/OFS-lib/UI/OFS_Videoplayer.h
@@ -105,7 +105,7 @@ private:
 
 
 		bool videoLoaded = false;
-		const char* filePath = nullptr;
+        std::string filePath = "";
 	} MpvData;
 
 
@@ -259,7 +259,7 @@ public:
 
 	void closeVideo() noexcept;
 
-	inline const char* getVideoPath() const noexcept { return (MpvData.filePath == nullptr) ? "" : MpvData.filePath; }
+	inline const char* getVideoPath() const noexcept { return MpvData.filePath.c_str(); }
 
 	inline uint32_t VideoWidth() const noexcept { return MpvData.videoWidth; }
 	inline uint32_t VideoHeight() const noexcept { return MpvData.videoHeight; }

--- a/src/UI/SpecialFunctions.cpp
+++ b/src/UI/SpecialFunctions.cpp
@@ -643,9 +643,9 @@ void CustomLua::resetVM() noexcept
             builder << "table.insert(LoadedScripts,Funscript:new())\n";
 
             // i+1 because lua indexing starts at 1 !!!
-            stbsp_snprintf(tmp, sizeof(tmp), "LoadedScripts[%d].title=[[%s]]\n", i+1, loadedScript->Title.c_str());
+            stbsp_snprintf(tmp, sizeof(tmp), "LoadedScripts[%d].title=[=[%s]=]\n", i+1, loadedScript->Title.c_str());
             builder << tmp;
-            stbsp_snprintf(tmp, sizeof(tmp), "LoadedScripts[%d].path=[[%s]]\n", i+1, loadedScript->Path().c_str());
+            stbsp_snprintf(tmp, sizeof(tmp), "LoadedScripts[%d].path=[=[%s]=]\n", i+1, loadedScript->Path().c_str());
             builder << tmp;
 
             for (auto&& action : loadedScript->Actions()) {
@@ -668,14 +668,14 @@ void CustomLua::resetVM() noexcept
 
         {
             // paths
-            stbsp_snprintf(tmp, sizeof(tmp), "VideoFilePath=[[%s]]\n", app->player->getVideoPath());
-            builder << tmp;
-
             auto vPath = app->player->getVideoPath();
             if (vPath) {
+                stbsp_snprintf(tmp, sizeof(tmp), "VideoFilePath=[=[%s]=]\n", app->player->getVideoPath());
+                builder << tmp;
+
                 auto path = Util::PathFromString(vPath);
                 path.replace_filename("");
-                stbsp_snprintf(tmp, sizeof(tmp), "VideoFileDirectory=[[%s]]\n", path.u8string().c_str());
+                stbsp_snprintf(tmp, sizeof(tmp), "VideoFileDirectory=[=[%s]=]\n", path.u8string().c_str());
                 builder << tmp;
             }
         }


### PR DESCRIPTION
This fix should allow square brackets in the filename. In the current code square brackets only works within OFS but not in the Lua scripts. If a square bracket is included in the filename we get an `unexpected symbol near ']'` error. 