### PR TITLE
[Feature] option to toggle display of meta data editor on new project

### DIFF
--- a/src/OpenFunscripter.cpp
+++ b/src/OpenFunscripter.cpp
@@ -1953,7 +1953,7 @@ void OpenFunscripter::initProject() noexcept
     OFS_PROFILE(__FUNCTION__);
     if (LoadedProject->Loaded) {
         if (LoadedProject->ProjectSettings.NudgeMetadata) {
-            ShowMetadataEditor = true;
+            ShowMetadataEditor = settings->data().show_meta_on_new;
             LoadedProject->ProjectSettings.NudgeMetadata = false;
         }
 

--- a/src/UI/OFS_Settings.cpp
+++ b/src/UI/OFS_Settings.cpp
@@ -135,6 +135,10 @@ bool OFS_Settings::ShowPreferenceWindow() noexcept
 						scripterSettings.fast_step_amount = Util::Clamp<int32_t>(scripterSettings.fast_step_amount, 2, 30);
 					}
 					OFS::Tooltip("Amount of frames to skip with fast step.");
+					ImGui::Separator();
+					if (ImGui::Checkbox("Show metadata dialog on new project", &scripterSettings.show_meta_on_new)) {
+						save = true;
+					}
 					ImGui::EndTabItem();
 				}
 				ImGui::EndTabBar();

--- a/src/UI/OFS_Settings.h
+++ b/src/UI/OFS_Settings.h
@@ -54,7 +54,7 @@ private:
 		bool mirror_mode = false;
 		bool show_tcode = false;
 		bool show_debug_log = false;
-		bool show_meta_on_new = true;
+		bool show_meta_on_new = false;
 
 		int32_t	vsync = 0;
 		int32_t framerateLimit = 150;
@@ -116,6 +116,7 @@ private:
 			OFS_REFLECT(show_tcode, ar);
 			OFS_REFLECT(defaultMetadata, ar);
 			OFS_REFLECT(show_debug_log, ar);
+			OFS_REFLECT(show_meta_on_new, ar);
 			OFS_REFLECT_NAMED("SplineMode", BaseOverlay::SplineMode, ar);
 			OFS_REFLECT_NAMED("SyncLineEnable", BaseOverlay::SyncLineEnable, ar);
 			OFS_REFLECT(defaultSimulatorConfig, ar);

--- a/src/UI/OFS_Settings.h
+++ b/src/UI/OFS_Settings.h
@@ -54,6 +54,7 @@ private:
 		bool mirror_mode = false;
 		bool show_tcode = false;
 		bool show_debug_log = false;
+		bool show_meta_on_new = true;
 
 		int32_t	vsync = 0;
 		int32_t framerateLimit = 150;


### PR DESCRIPTION
Sometimes I would just want to open some videos in OFS to try working/testing on it without creating a project.
However the metadata windows always shows up on new video import and has to be manually closed.
I added an option to have it togglable.