### PR TITLE
only add to recent files on saving/loading project

### DIFF
--- a/src/OFS_Project.cpp
+++ b/src/OFS_Project.cpp
@@ -215,9 +215,6 @@ void OFS_Project::Save(const std::string& path, bool clearUnsavedChanges) noexce
 	if (clearUnsavedChanges) {
 		for (auto& script : Funscripts) script->SetSavedFromOutside();
 	}
-
-	auto recentFile = OFS_Settings::RecentFile{ Metadata.title, LastPath };
-	OpenFunscripter::ptr->settings->addRecentFile(recentFile);
 }
 
 void OFS_Project::AddFunscript(const std::string& path) noexcept

--- a/src/OFS_Project.cpp
+++ b/src/OFS_Project.cpp
@@ -215,6 +215,9 @@ void OFS_Project::Save(const std::string& path, bool clearUnsavedChanges) noexce
 	if (clearUnsavedChanges) {
 		for (auto& script : Funscripts) script->SetSavedFromOutside();
 	}
+
+	auto recentFile = OFS_Settings::RecentFile{ Metadata.title, LastPath };
+	OpenFunscripter::ptr->settings->addRecentFile(recentFile);
 }
 
 void OFS_Project::AddFunscript(const std::string& path) noexcept

--- a/src/OpenFunscripter.cpp
+++ b/src/OpenFunscripter.cpp
@@ -1530,8 +1530,6 @@ void OpenFunscripter::MpvVideoLoaded(SDL_Event& ev) noexcept
     Status |= OFS_Status::OFS_GradientNeedsUpdate;
     const char* VideoName = (const char*)ev.user.data1;
     if (VideoName) {
-        auto recentFile = OFS_Settings::RecentFile{ LoadedProject->Metadata.title, LoadedProject->LastPath };
-        settings->addRecentFile(recentFile);
         scriptPositions.ClearAudioWaveform();
     }
 
@@ -1945,6 +1943,8 @@ bool OpenFunscripter::openProject(const std::string& file, bool withFailDialog) 
         return false;
     }
     initProject();
+    auto recentFile = OFS_Settings::RecentFile{ LoadedProject->Metadata.title, LoadedProject->LastPath };
+    settings->addRecentFile(recentFile);
     return true;
 }
 

--- a/src/OpenFunscripter.cpp
+++ b/src/OpenFunscripter.cpp
@@ -2006,6 +2006,8 @@ void OpenFunscripter::saveProject() noexcept
 {
     OFS_PROFILE(__FUNCTION__);
     LoadedProject->Save(true);
+    auto recentFile = OFS_Settings::RecentFile{ LoadedProject->Metadata.title, LoadedProject->LastPath };
+    settings->addRecentFile(recentFile);
 }
 
 void OpenFunscripter::quickExport() noexcept


### PR DESCRIPTION
Adding file to Recent file list is linked to loading of video. However it does not guarantee creation of project files, causing empty entries. It should be linked to opening and saving of projects.