### PR TITLE
Added Feature "Lock FPS" for the simulator graph.

### DIFF
--- a/OFS-lib/UI/OFS_Videoplayer.cpp
+++ b/OFS-lib/UI/OFS_Videoplayer.cpp
@@ -223,6 +223,10 @@ void VideoplayerWindow::renderToTexture() noexcept
 		mpv_render_param{}
 	};
 	mpv_render_context_render(mpv_gl, params);
+
+	MpvData.framePercentPos = MpvData.percentPos;
+	frameSmoothTime = smoothTime;
+
 }
 
 void VideoplayerWindow::updateRenderTexture() noexcept

--- a/OFS-lib/UI/OFS_Videoplayer.h
+++ b/OFS-lib/UI/OFS_Videoplayer.h
@@ -58,6 +58,7 @@ private:
 	float lastVideoStep = 0.f;
 	float baseScaleFactor = 1.f;
 	float smoothTime = 0.f;
+	float frameSmoothTime = 0.f;
 	bool correctPlaybackErrorActive = false;
 	bool videoHovered = false;
 	bool dragStarted = false;
@@ -91,6 +92,7 @@ private:
 		double duration = 1.0;
 		double percentPos = 0.0;
 		double realPercentPos = 0.0;
+		double framePercentPos = 0.0;
 		double currentSpeed = 1.0;
 		double fps = 30.0;
 		double averageFrameTime = 1.0/fps;
@@ -216,6 +218,21 @@ public:
 	inline double getCurrentPositionSeconds() const noexcept { 
 		return MpvData.percentPos * MpvData.duration; 
 	}
+
+	inline double getFramePositionSecondsInterp() const noexcept {
+		OFS_PROFILE(__FUNCTION__);
+		if (MpvData.paused) {
+			return getFramePositionSeconds();
+		}
+		else {
+			return getFramePositionSeconds() + frameSmoothTime;
+		}
+	}
+
+	inline double getFramePositionSeconds() const noexcept {
+		return MpvData.framePercentPos * MpvData.duration;
+	}
+
 
 	inline double getRealCurrentPositionSeconds() const noexcept { return MpvData.realPercentPos * MpvData.duration;  }
 	inline void syncWithRealTime() noexcept { MpvData.percentPos = MpvData.realPercentPos; }

--- a/src/UI/OFS_ScriptSimulator.h
+++ b/src/UI/OFS_ScriptSimulator.h
@@ -43,6 +43,7 @@ public:
 		bool EnablePosition = false;
 		bool EnableHeightLines = true;
 		bool LockedPosition = false;
+		bool LockedFPS = false;
 
 		template <class Archive>
 		inline void reflect(Archive& ar)
@@ -65,6 +66,7 @@ public:
 			OFS_REFLECT(EnableHeightLines, ar);
 			OFS_REFLECT(ExtraLinesCount, ar);
 			OFS_REFLECT(LockedPosition, ar);
+			OFS_REFLECT(LockedFPS, ar);
 		}
 
 		template<typename S>
@@ -93,6 +95,7 @@ public:
 					s.boolValue(o.EnablePosition);
 					s.boolValue(o.EnableHeightLines);
 					s.boolValue(o.LockedPosition);
+					s.boolValue(o.LockedFPS);
 					s.value4b(o.ExtraLinesCount);
 				});
 		}


### PR DESCRIPTION
Hi there!

This probably needs some review, because I'm not sure if that's the desired way to implement stuff in OFS :) 

This patch adds Feature "Lock FPS" for the simulator graph. This introduces two new variables MpvData.FramePercentpos and VideplayerWindows::realSmoothTime, which will only get updated with the current video position whenever a new video frame is actually rendered.

That means, the simulator always matches the displayed frame, which is especially useful when stepping forwards and backwards manually and the codec needing some time to serve the upcoming frame.

A new setting ScriptSimulator::LockedFPS and a checkbox in the UIis introduced, default is off.

I took the easy way, and crated a new getFramePositionSeconds() function analog to getCurrentPositionSeconds() - the alternative would have been to introduce a new parameter to the existing function to choose if you want the actual timeline position or the displayed frame position - but I wanted to keep the chances as straightforward as possible. 

Let me know what you think.