### PR TITLE
Fixes the macOS data folder location

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,9 +38,15 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR})
 
 # copy data directory
-add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
-					COMMAND ${CMAKE_COMMAND} -E copy_directory
-					"${CMAKE_SOURCE_DIR}/data/" "$<TARGET_FILE_DIR:${PROJECT_NAME}>/data")
+if(APPLE)
+	add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+						COMMAND ${CMAKE_COMMAND} -E copy_directory
+						"${CMAKE_SOURCE_DIR}/data/" "$<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/data")
+else()
+	add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+						COMMAND ${CMAKE_COMMAND} -E copy_directory
+						"${CMAKE_SOURCE_DIR}/data/" "$<TARGET_FILE_DIR:${PROJECT_NAME}>/data")
+endif()
 
 
 target_link_libraries(${PROJECT_NAME} PUBLIC


### PR DESCRIPTION
Hi! This patch should fix the issue mentioned in bug #23

For macOS only, this changes the location of the "data" folder containing fonts, lua scripts, etc. so it gets copied to `OpenFunscripter.app/Contents/Resources/data/`

(Previously it would copy to `OpenFunscripter.app/Contents/MacOS/data/` and then when running the app it would crash as it couldn't find the fonts.)