### PR TITLE
Fixed openfile dialog for macOS

### DIFF
--- a/OFS-lib/OFS_Util.cpp
+++ b/OFS-lib/OFS_Util.cpp
@@ -184,6 +184,8 @@ void Util::OpenFileDialog(const std::string& title, const std::string& path, Fil
 			wc_str.push_back(wfilters.back().c_str());
 		}
 		auto result = tinyfd_utf16to8(tinyfd_openFileDialogW(wtitle.c_str(), wpath.c_str(), wc_str.size(), wc_str.data(), wfilterText.empty() ? NULL : wfilterText.c_str(), data->multiple));
+#elif __APPLE__
+		auto result = tinyfd_openFileDialog(data->title.c_str(), data->path.c_str(), 0, nullptr, data->filterText.empty() ? NULL : data->filterText.c_str(), data->multiple);
 #else
 		auto result = tinyfd_openFileDialog(data->title.c_str(), data->path.c_str(), data->filters.size(), data->filters.data(), data->filterText.empty() ? NULL : data->filterText.c_str(), data->multiple);
 #endif


### PR DESCRIPTION
The way tinyfd implements open file dialog uses applescript, and in applescript you can only select approved/standardized filetypes, meaning ofsp cannot be selected, whereas mp4 can.
This patch removes the filetype filter if compiled for macOS.