### PR TITLE
remove __debugbreak() in LuaExtensions

### DIFF
--- a/src/lua/OFS_LuaExtension.cpp
+++ b/src/lua/OFS_LuaExtension.cpp
@@ -137,13 +137,11 @@ bool OFS_LuaExtension::Load() noexcept
 #ifndef NDEBUG
 	L.set_exception_handler([](lua_State* L, auto optEx, std::string_view msg)
 	{
-		__debugbreak();
 		return 0;
 	});
 
 	L.set_panic([](lua_State* L)
 	{
-		__debugbreak();
 		return 0;
 	});
 #endif


### PR DESCRIPTION
This caused the compile to fail on linux.
most likely pushed by accident.