### PR TITLE
Implement player.Width() and player.Height() in lua extension

### DIFF
--- a/LuaDox/stubs.lua
+++ b/LuaDox/stubs.lua
@@ -228,6 +228,14 @@ function player.CurrentVideo() end
 -- @treturn number FPS
 function player.FPS() end
 
+--- Get the width of the video
+-- @treturn number Pixels
+function player.Width() end
+
+--- Get the height of the video
+-- @treturn number Pixels
+function player.Height() end
+
 --- Control playback speed
 --
 -- The value is automatically clamped between 0.05 minimum speed and 3.0 maximum speed

--- a/src/lua/api/OFS_LuaPlayerAPI.cpp
+++ b/src/lua/api/OFS_LuaPlayerAPI.cpp
@@ -22,6 +22,8 @@ OFS_PlayerAPI::OFS_PlayerAPI(sol::state_view& L) noexcept
     player["IsPlaying"] = OFS_PlayerAPI::IsPlaying;
     player["CurrentVideo"] = OFS_PlayerAPI::CurrentVideo;
     player["FPS"] = OFS_PlayerAPI::FPS;
+    player["Width"] = OFS_PlayerAPI::VideoWidth;
+    player["Height"] = OFS_PlayerAPI::VideoHeight;
 
     player["playbackSpeed"] = sol::property(OFS_PlayerAPI::getPlaybackSpeed, OFS_PlayerAPI::setPlaybackSpeed);
 }
@@ -84,4 +86,16 @@ lua_Number OFS_PlayerAPI::getPlaybackSpeed() noexcept
 {
     auto app = OpenFunscripter::ptr;
     return app->player->getSpeed();
+}
+
+lua_Number OFS_PlayerAPI::VideoWidth() noexcept
+{
+    auto app = OpenFunscripter::ptr;
+    return app->player->VideoWidth();
+}
+
+lua_Number OFS_PlayerAPI::VideoHeight() noexcept
+{
+    auto app = OpenFunscripter::ptr;
+    return app->player->VideoHeight();
 }

--- a/src/lua/api/OFS_LuaPlayerAPI.h
+++ b/src/lua/api/OFS_LuaPlayerAPI.h
@@ -16,6 +16,8 @@ class OFS_PlayerAPI
 
     static void setPlaybackSpeed(lua_Number speed) noexcept;
     static lua_Number getPlaybackSpeed() noexcept;
+    static lua_Number VideoWidth() noexcept;
+    static lua_Number VideoHeight() noexcept;
 
     public:
     OFS_PlayerAPI(sol::state_view& L) noexcept;


### PR DESCRIPTION
The video dimension may come in handy when calling external program for processing.