### PR TITLE
Load recent project name glyph on start

### DIFF
--- a/src/OpenFunscripter.cpp
+++ b/src/OpenFunscripter.cpp
@@ -2533,6 +2533,7 @@ void OpenFunscripter::ShowMainMenuBar() noexcept
                 auto& recentFiles = settings->data().recentFiles;
                 for (auto it = recentFiles.rbegin(); it != recentFiles.rend(); it++) {
                     auto& recent = *it;
+                    OFS_DynFontAtlas::AddText(recent.name.c_str());
                     if (ImGui::MenuItem(recent.name.c_str())) {
                         if (!recent.projectPath.empty()) {
                             closeWithoutSavingDialog([this, clickedFile = recent.projectPath]() 


### PR DESCRIPTION
On OFS start up, recent projects with unicode names is not loaded correctly (showing as question marks).
I added a AddText call before adding recent project to the menu item to load the necessary unicode glyph.